### PR TITLE
Change dependency to refer upstream.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,10 @@
     "random-string": "~0.1.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.1",
+    "sequelize": "1.7.x"
   },
   "keywords": [
     "gruntplugin"
-  ],
-  "dependencies": {
-    "sequelize": "~1.7.0"
-  }
+  ]
 }


### PR DESCRIPTION
The guys working on Sequelize have marked the 1.7.0 branch as the most current, stable release, so I opted to use that as the semver.
